### PR TITLE
Mitigate issues with JNI bindings by updating Kotlin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ version = "0.1.2"
 plugins {
     id("tanvd.kosogor") version "1.0.7" apply true
     id("io.gitlab.arturbosch.detekt").version("1.0.0-RC14") apply true
-    kotlin("jvm") version "1.3.50" apply false
+    kotlin("jvm") version "1.3.61" apply false
 }
 
 configureIdea {

--- a/dsl/common/lang-parser-common/src/main/kotlin/io/kotless/parser/utils/psi/analysis/EnvironmentManager.kt
+++ b/dsl/common/lang-parser-common/src/main/kotlin/io/kotless/parser/utils/psi/analysis/EnvironmentManager.kt
@@ -2,6 +2,7 @@ package io.kotless.parser.utils.psi.analysis
 
 
 import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
+import org.jetbrains.kotlin.cli.common.environment.setIdeaIoUseFallback
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
@@ -25,6 +26,8 @@ import java.io.File
 object EnvironmentManager {
     /** Create KotlinCoreEnvironment with specified classpath */
     fun create(libraries: Set<File>): KotlinCoreEnvironment {
+        setIdeaIoUseFallback()
+
         val configuration = CompilerConfiguration().apply {
             addJvmClasspathRoots(PathUtil.getJdkClassesRootsFromCurrentJre() + libraries)
             put(CommonConfigurationKeys.MODULE_NAME, DEFAULT_MODULE_NAME)


### PR DESCRIPTION
There is an intricate problem with the `kotlin-compiler-embeddable` module in version `1.3.50` that messes with JNI bindings under certain circumstances.

I do not understand the underlying issue in all of its glory, but I was able to figure out a workaround by googling and looking at other projects' issues and PRs.

See also https://github.com/JetBrains/kotlin/commit/2568804eaa2c8f6b10b735777218c81af62919c1
See also https://github.com/arturbosch/detekt/issues/2118