### PR TITLE
Allow headless plugin usage

### DIFF
--- a/plugins/gradle/src/main/kotlin/io/kotless/plugin/gradle/KotlessDeployTasks.kt
+++ b/plugins/gradle/src/main/kotlin/io/kotless/plugin/gradle/KotlessDeployTasks.kt
@@ -11,6 +11,12 @@ import org.gradle.api.Task
 object KotlessDeployTasks {
 
     fun Project.setupDeployTasks(download: Task) {
+        if (kotless.config.bucket.isEmpty()) {
+            logger.warn("Configuration succeeded, but Kotless requires `kotless { bucket = \"...\" }` for actual deployment")
+            logger.warn("Terraform deployment tasks will NOT be added to this project")
+            return
+        }
+        
         with(tasks) {
             val generate = myCreate<KotlessGenerateTask>("generate")
 

--- a/plugins/gradle/src/main/kotlin/io/kotless/plugin/gradle/KotlessPlugin.kt
+++ b/plugins/gradle/src/main/kotlin/io/kotless/plugin/gradle/KotlessPlugin.kt
@@ -27,6 +27,8 @@ class KotlessPlugin : Plugin<Project> {
 
             configurations.create(myLocalConfigurationName)
 
+            kotless = KotlessDSL(this)
+
             with(tasks) {
                 val download = myCreate<TerraformDownloadTask>("download_terraform")
 

--- a/plugins/gradle/src/main/kotlin/io/kotless/plugin/gradle/dsl/KotlessConfig.kt
+++ b/plugins/gradle/src/main/kotlin/io/kotless/plugin/gradle/dsl/KotlessConfig.kt
@@ -10,7 +10,7 @@ import java.io.Serializable
 @KotlessDSLTag
 class KotlessConfig(project: Project) : Serializable {
     /** Name of bucket Kotless will use to store all files */
-    lateinit var bucket: String
+    var bucket: String = ""
 
     /** Prefix with which all created resources will be prepended */
     var prefix: String = ""

--- a/plugins/gradle/src/main/kotlin/io/kotless/plugin/gradle/dsl/KotlessConfig.kt
+++ b/plugins/gradle/src/main/kotlin/io/kotless/plugin/gradle/dsl/KotlessConfig.kt
@@ -47,7 +47,7 @@ class KotlessConfig(project: Project) : Serializable {
     @KotlessDSLTag
     class DSLConfig(project: Project) : Serializable {
         /** Type of DSL used by Kotless */
-        lateinit var type: DSLType
+        var type: DSLType = DSLType.Kotless
 
         /**
          * Directory Kotless considers as root for File resolving

--- a/plugins/gradle/src/main/kotlin/io/kotless/plugin/gradle/dsl/KotlessDSL.kt
+++ b/plugins/gradle/src/main/kotlin/io/kotless/plugin/gradle/dsl/KotlessDSL.kt
@@ -13,7 +13,7 @@ class KotlessDSL(project: Project) : Serializable {
         config = config.apply(configure)
     }
 
-    internal lateinit var webapp: Webapp
+    internal var webapp: Webapp = Webapp()
     /** Configuration of Kotless Web application */
     @KotlessDSLTag
     fun webapp(configure: Webapp.() -> Unit) {


### PR DESCRIPTION
Currently, it is only possible to use the `kotless` Gradle plugin if one *exactly* follows the build file setup outlined in the readme. This means that stuff(TM) explodes when applying the plugin without a corresponding `kotless` configuration block.

In my opinion, the plugin should ship with reasonable defaults that allow the build script compilation to succeed, while still allowing the user to override defaults with their own configurations (like for example in the `README.md`) if they so desire.

This PR aims to provide such defaults. Please provide feedback on whether they are reasonable.