### PR TITLE
Allow static objects as Kotless entry point

### DIFF
--- a/dsl/ktor/ktor-lang-local/src/main/kotlin/io/kotless/dsl/ktor/Main.kt
+++ b/dsl/ktor/ktor-lang-local/src/main/kotlin/io/kotless/dsl/ktor/Main.kt
@@ -8,7 +8,11 @@ fun main() {
     val port = System.getenv("KTOR_PORT").toInt()
     val classToStart = System.getenv("CLASS_TO_START")
 
-    val kotless = ::main.javaClass.classLoader.loadClass(classToStart).kotlin.primaryConstructor!!.call() as Kotless
+    val ktClass = ::main.javaClass.classLoader.loadClass(classToStart).kotlin
+    val instance = ktClass.primaryConstructor?.call() ?: ktClass.objectInstance
+
+    val kotless = instance as? Kotless
+        ?: error("The entry point $classToStart does not inherit from ${Kotless::class.qualifiedName}!")
 
     embeddedServer(Netty, port) {
         kotless.prepare(this)


### PR DESCRIPTION
Currently, the `local` ktor task only detects classes that are implemented as actual classes. I reckon it makes sense to also allow for objects that inherit from `Kotless()`, so I went ahead and implemented support for that.

Now you can also do:

```kotlin
object MyWebservice : Kotless() {
  override fun prepare(app: Application) {
        app.doAwesomeStuff()
    }
}
```