### PR TITLE
#29 Handling KTOR io.ktor.http.content.default function is realized …

### DIFF
--- a/dsl/ktor/ktor-lang-parser/src/main/kotlin/io/kotless/parser/ktor/processor/route/StaticRoutesProcessor.kt
+++ b/dsl/ktor/ktor-lang-parser/src/main/kotlin/io/kotless/parser/ktor/processor/route/StaticRoutesProcessor.kt
@@ -15,7 +15,11 @@ import org.jetbrains.kotlin.resolve.BindingContext
 import java.io.File
 
 internal object StaticRoutesProcessor : SubTypesProcessor<Unit>() {
-    private val funcs = setOf("io.ktor.http.content.file", "io.ktor.http.content.files")
+    private val funcs = setOf(
+        "io.ktor.http.content.file",
+        "io.ktor.http.content.files",
+        "io.ktor.http.content.default"
+    )
 
     override val klasses = setOf(Kotless::class)
 
@@ -38,6 +42,13 @@ internal object StaticRoutesProcessor : SubTypesProcessor<Unit>() {
                                 val path = URIPath(outer, remotePath)
 
                                 createResource(file, path, context)
+                            }
+                            "io.ktor.http.content.default" -> {
+                                val localPath = element.getArgument("localPath", binding).asString(binding)
+
+                                val file = File(base, localPath)
+
+                                createResource(file, outer, context)
                             }
                             "io.ktor.http.content.files" -> {
                                 val folder = File(base, element.getArgument("folder", binding).asString(binding))


### PR DESCRIPTION
…that allows showing static/index.html file for /static GET-request
According to #29 

This solution is not completely graceful and requires further work. In it a new object is created with `createResource` instead of adding one more aws_api_gateway_integration. This leads to two S3 objects are created with the same file names ("static" for the example in #29 ). One is directory and another is a copy of index.html. This solution looks hacky but provides a fast working solution that can be refined later.

Later the code structure should be changed somehow. For instance a similar class as StaticRouteFactory to be created for this case, or the very StaticRouteFactory.