### PR TITLE
#27 Fix for recursive adding static files in KTOR framework

### DIFF
--- a/dsl/ktor/ktor-lang-parser/src/main/kotlin/io/kotless/parser/ktor/processor/route/StaticRoutesProcessor.kt
+++ b/dsl/ktor/ktor-lang-parser/src/main/kotlin/io/kotless/parser/ktor/processor/route/StaticRoutesProcessor.kt
@@ -42,19 +42,27 @@ internal object StaticRoutesProcessor : SubTypesProcessor<Unit>() {
                             "io.ktor.http.content.files" -> {
                                 val folder = File(base, element.getArgument("folder", binding).asString(binding))
 
-                                val allFiles = folder.listFiles() ?: emptyArray()
-
-                                for (file in allFiles) {
-                                    val remotePath = file.toRelativeString(folder).toURIPath()
-                                    val path = URIPath(outer, remotePath)
-
-                                    createResource(file, path, context)
-                                }
+                                addStaticFolder(folder, outer, context)
                             }
                         }
                     }
                     true
                 }
+            }
+        }
+    }
+
+    private fun addStaticFolder(folder: File, outer: URIPath, context: ProcessorContext) {
+        val allFiles = folder.listFiles() ?: emptyArray()
+
+        for (file in allFiles) {
+            if (file.isDirectory) {
+                addStaticFolder(file, URIPath(outer, file.name), context)
+            } else {
+                val remotePath = file.toRelativeString(folder).toURIPath()
+                val path = URIPath(outer, remotePath)
+
+                createResource(file, path, context)
             }
         }
     }


### PR DESCRIPTION
This pull request closes bug #27 that  skipped subfolders files by `io.ktor.http.content.files` handler.