### PR TITLE
Fixed issue with decoding requests without user agent on AWS Lambda

### DIFF
--- a/dsl/common/lang-common/src/main/kotlin/io/kotless/dsl/model/HTTP.kt
+++ b/dsl/common/lang-common/src/main/kotlin/io/kotless/dsl/model/HTTP.kt
@@ -51,7 +51,7 @@ data class HttpRequest(
         val stagePath = path.dropLast(resourcePath.length - 1)
 
         @Serializable
-        data class RequestIdentity(val sourceIp: String, val userAgent: String)
+        data class RequestIdentity(val sourceIp: String, val userAgent: String?)
     }
 }
 


### PR DESCRIPTION
Sometimes HTTP requests may come without `User-Agent` defined, so the corresponding field should be nullable.