### PR TITLE
fixed warning message for plugin without configuration

### DIFF
--- a/plugins/gradle/src/main/kotlin/io/kotless/plugin/gradle/KotlessDeployTasks.kt
+++ b/plugins/gradle/src/main/kotlin/io/kotless/plugin/gradle/KotlessDeployTasks.kt
@@ -15,7 +15,7 @@ import org.gradle.kotlin.dsl.get
 internal object KotlessDeployTasks {
     fun Project.setupDeployTasks(download: Task) {
         if (kotless.config.bucket.isEmpty()) {
-            logger.warn("Configuration succeeded, but Kotless requires `kotless { bucket = \"...\" }` for actual deployment")
+            logger.warn("Configuration succeeded, but Kotless requires `kotless { config { bucket = \"...\" } }` for actual deployment")
             logger.warn("Deployment tasks will NOT be added to this project")
             return
         }


### PR DESCRIPTION
before
```
kotlin {
    bucket = "..."
}
```

after
```
kotlin {
  config {
    bucket = "..."
  }
}
```