### PR TITLE
[plugin] Update localstack to latest RC

### DIFF
--- a/plugins/gradle/build.gradle.kts
+++ b/plugins/gradle/build.gradle.kts
@@ -38,7 +38,7 @@ dependencies {
     implementation("com.github.jengelman.gradle.plugins", "shadow", "6.0.0")
 
     implementation("com.amazonaws", "aws-java-sdk-core", Versions.aws)
-    implementation("org.testcontainers", "localstack", "1.14.3")
+    implementation("org.testcontainers", "localstack", "1.15.0-rc2")
 
     implementation("org.codehaus.plexus", "plexus-utils", "3.3.0")
     implementation("org.codehaus.plexus", "plexus-archiver", "4.2.1")


### PR DESCRIPTION
Docker for Mac 2.4.0.0 introduced a breaking change breaking testcontainers ryuk on MacOS. [Also see the testcontainer issue.](https://github.com/testcontainers/testcontainers-java/issues/3166)