### PR TITLE
Add locals to Terraform configuration

### DIFF
--- a/engine/src/main/kotlin/io/kotless/gen/Generator.kt
+++ b/engine/src/main/kotlin/io/kotless/gen/Generator.kt
@@ -8,6 +8,7 @@ import io.kotless.gen.factory.event.ScheduledEventsFactory
 import io.kotless.gen.factory.info.InfoFactory
 import io.kotless.gen.factory.infra.TFConfigFactory
 import io.kotless.gen.factory.infra.TFProvidersFactory
+import io.kotless.gen.factory.infra.TFLocalsFactory
 import io.kotless.gen.factory.resource.dynamic.LambdaFactory
 import io.kotless.gen.factory.resource.static.StaticResourceFactory
 import io.kotless.gen.factory.route.dynamic.DynamicRouteFactory
@@ -24,7 +25,7 @@ import kotlin.reflect.KClass
 object Generator {
     private val factories: Map<KClass<*>, Set<GenerationFactory<*, *>>> = mapOf(
         Application::class to setOf(InfoFactory, StaticRoleFactory),
-        KotlessConfig.Terraform::class to setOf(TFConfigFactory, TFProvidersFactory),
+        KotlessConfig.Terraform::class to setOf(TFConfigFactory, TFProvidersFactory, TFLocalsFactory),
 
         Application.ApiGateway::class to setOf(DomainFactory, RestAPIFactory),
         Application.ApiGateway.Deployment::class to setOf(DeploymentFactory),

--- a/engine/src/main/kotlin/io/kotless/gen/factory/infra/TFLocalsFactory.kt
+++ b/engine/src/main/kotlin/io/kotless/gen/factory/infra/TFLocalsFactory.kt
@@ -1,0 +1,27 @@
+package io.kotless.gen.factory.infra
+
+import io.kotless.KotlessConfig
+import io.kotless.gen.GenerationContext
+import io.kotless.gen.GenerationFactory
+import io.kotless.hcl.HCLEntity
+import io.kotless.hcl.HCLTextField
+import io.kotless.terraform.infra.TFLocals
+import io.kotless.terraform.infra.locals
+
+object TFLocalsFactory : GenerationFactory<KotlessConfig.Terraform, Unit> {
+
+    override fun mayRun(entity: KotlessConfig.Terraform, context: GenerationContext) = true
+
+    override fun generate(entity: KotlessConfig.Terraform, context: GenerationContext): GenerationFactory.GenerationResult<Unit> {
+        val locals = locals {
+            variables = object : HCLEntity() {
+                init {
+                    for ((key, value) in entity.locals) {
+                        fields.add(HCLTextField(key, false, this, value))
+                    }
+                }
+            }
+        }
+        return GenerationFactory.GenerationResult(Unit, locals)
+    }
+}

--- a/engine/src/main/kotlin/io/kotless/terraform/infra/TFLocals.kt
+++ b/engine/src/main/kotlin/io/kotless/terraform/infra/TFLocals.kt
@@ -1,0 +1,27 @@
+package io.kotless.terraform.infra
+
+import io.kotless.hcl.HCLEntity
+import io.kotless.terraform.TFFile
+import io.kotless.utils.withIndent
+
+class TFLocals : HCLEntity.Named() {
+
+    var variables by entity<HCLEntity>()
+
+    override val hcl_name: String = "locals"
+
+    override val hcl_ref: String
+        get() = hcl_name
+
+    override fun render(): String = """
+        |$hcl_name {
+        |${variables.render().withIndent()}
+        |}
+        """.trimMargin()
+}
+
+fun locals(configure: TFLocals.() -> Unit) = TFLocals().apply(configure)
+
+fun TFFile.locals(configure: TFLocals.() -> Unit) {
+    add(TFLocals().apply(configure))
+}

--- a/plugins/gradle/src/main/kotlin/io/kotless/plugin/gradle/dsl/Converters.kt
+++ b/plugins/gradle/src/main/kotlin/io/kotless/plugin/gradle/dsl/Converters.kt
@@ -2,6 +2,8 @@ package io.kotless.plugin.gradle.dsl
 
 import io.kotless.KotlessConfig
 
+const val KOTLESS_ENVIRONMENT = "kotless_environment"
+
 internal fun KotlessDSL.toSchema(): KotlessConfig {
     return with(config) {
         KotlessConfig(bucket, prefix, KotlessConfig.DSL(dsl.typeOrDefault, dsl.resolvedStaticsRoot),
@@ -18,7 +20,8 @@ internal fun KotlessDSL.toSchema(): KotlessConfig {
                         provider.version,
                         provider.profile ?: profile,
                         provider.region ?: region
-                    )
+                    ),
+                    this@toSchema.extensions.terraform.locals + (KOTLESS_ENVIRONMENT to "remote")
                 )
             },
             KotlessConfig.Optimization(

--- a/plugins/gradle/src/main/kotlin/io/kotless/plugin/gradle/dsl/Extensions.kt
+++ b/plugins/gradle/src/main/kotlin/io/kotless/plugin/gradle/dsl/Extensions.kt
@@ -11,6 +11,9 @@ class Extensions : Serializable {
         /** Allow usage of Destroy task */
         var allowDestroy = false
 
+        /** Additional locals that can be used to customize Terraform configuration */
+        val locals: HashMap<String, String> = HashMap()
+
         @KotlessDSLTag
         class Files : Serializable {
             internal val additional = HashSet<File>()

--- a/plugins/gradle/src/main/kotlin/io/kotless/plugin/gradle/tasks/gen/KotlessLocalGenerateTask.kt
+++ b/plugins/gradle/src/main/kotlin/io/kotless/plugin/gradle/tasks/gen/KotlessLocalGenerateTask.kt
@@ -1,12 +1,16 @@
 package io.kotless.plugin.gradle.tasks.gen
 
 import io.kotless.AwsResource
+import io.kotless.hcl.HCLEntity
+import io.kotless.hcl.HCLTextField
+import io.kotless.plugin.gradle.dsl.KOTLESS_ENVIRONMENT
 import io.kotless.plugin.gradle.dsl.KotlessDSL
 import io.kotless.plugin.gradle.dsl.kotless
 import io.kotless.plugin.gradle.utils.gradle.Groups
 import io.kotless.plugin.gradle.utils.gradle.clearDirectory
 import io.kotless.terraform.TFFile
 import io.kotless.terraform.infra.aws_provider
+import io.kotless.terraform.infra.locals
 import io.kotless.terraform.infra.terraform
 import io.kotless.terraform.tf
 import org.codehaus.plexus.util.FileUtils
@@ -54,6 +58,18 @@ internal open class KotlessLocalGenerateTask : DefaultTask() {
                 skip_requesting_account_id = true
 
                 endpoints(services.mapKeys { it.key.prefix })
+            }
+
+            val localVariables = myKotless.extensions.terraform.locals + (KOTLESS_ENVIRONMENT to "local")
+
+            locals {
+                variables = object : HCLEntity() {
+                    init {
+                        for ((key, value) in localVariables) {
+                            fields.add(HCLTextField(key, false, this, value))
+                        }
+                    }
+                }
             }
         }
 

--- a/schema/src/main/kotlin/io/kotless/KotlessConfig.kt
+++ b/schema/src/main/kotlin/io/kotless/KotlessConfig.kt
@@ -32,7 +32,7 @@ data class KotlessConfig(
      *
      * @param version version of Terraform used
      */
-    data class Terraform(val version: String, val backend: Backend, val aws: AWSProvider) : Visitable {
+    data class Terraform(val version: String, val backend: Backend, val aws: AWSProvider, val locals: Map<String, String>) : Visitable {
 
         /**
          * Configuration of Terraform backend


### PR DESCRIPTION
Kotless extensions block can be used to add local variables to Terraform configuration.
`kotless_environment` variable gets added automatically with values **remote** or **local**.

This allows us to fine tune the configuration in custom Terraform files by checking for variable values, for example to only add a resource when we have a remote environment configuration:

```
resource "aws_iam_role_policy" "policy_name" {
  count = ${local.kotless_environment == "remote" ? 1: 0}
  role = aws_iam_role.role.name
  policy = data.aws_iam_policy_document.document.json
}
```

To add additional variables we can use the extensions block:

```
kotless {
  extensions {
    terraform {
      files {
        add(file("terraform/custom_configuration.tf"))
      }
      locals["EXTRA_VARIABLE"] = "value"
    }
  }
}
```