### PR TITLE
Add permission for query/scan all DynamoDB indexes

### DIFF
--- a/dsl/common/lang-parser-common/src/main/kotlin/io/kotless/parser/processor/permission/PermissionsProcessor.kt
+++ b/dsl/common/lang-parser-common/src/main/kotlin/io/kotless/parser/processor/permission/PermissionsProcessor.kt
@@ -47,6 +47,7 @@ object PermissionsProcessor {
                         val id = annotation.getValue(context, DynamoDBTable::table)!!
                         val level = annotation.getEnumValue(context, DynamoDBTable::level)!!
                         permissions.add(Permission(AwsResource.DynamoDB, level, setOf("table/$id")))
+                        permissions.add(Permission(AwsResource.DynamoDBIndex, level, setOf("table/$id/index/*")))
                     }
                 }
             }

--- a/model/src/main/kotlin/io/kotless/Permission.kt
+++ b/model/src/main/kotlin/io/kotless/Permission.kt
@@ -18,6 +18,11 @@ enum class AwsResource(val prefix: String, val glob: (region: String, account: S
         read = setOf("BatchGetItem", "GetItem", "TransactGetItems", "Query", "Scan", "Describe*", "List*"),
         write = setOf("BatchWriteItem", "PutItem", "TransactWriteItems", "Create*", "Delete*", "Restore*", "Update*", "TagResource", "UntagResource")
     ),
+    DynamoDBIndex("dynamodb",
+        glob = { region, account -> "arn:aws:dynamodb:$region:$account" },
+        read = setOf("Query", "Scan"),
+        write = setOf()
+    ),
     CloudWatchLogs("logs",
         glob = { region, account -> "arn:aws:logs:$region:$account" },
         read = setOf("GetLogEvents", "GetLogRecord", "GetLogGroupFields", "GetQueryResults", "DescribeLogGroups", "DescribeLogStreams", "DescribeMetricFilters"),

--- a/plugins/gradle/src/test/resources/examples/kotless/shortener/shortener.tf
+++ b/plugins/gradle/src/test/resources/examples/kotless/shortener/shortener.tf
@@ -446,6 +446,11 @@ data "aws_iam_policy_document" "merged_0" {
   }
   statement {
     effect = "Allow"
+    resources = ["arn:aws:dynamodb:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:table/short-url-table/index/*"]
+    actions = ["dynamodb:Query", "dynamodb:Scan"]
+  }
+  statement {
+    effect = "Allow"
     resources = ["arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"]
     actions = ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:DeleteLogGroup", "logs:DeleteLogStream", "logs:DeleteMetricFilter", "logs:DescribeLogGroups", "logs:DescribeLogStreams", "logs:DescribeMetricFilters", "logs:GetLogEvents", "logs:GetLogGroupFields", "logs:GetLogRecord", "logs:GetQueryResults", "logs:PutLogEvents", "logs:PutMetricFilter"]
   }

--- a/plugins/gradle/src/test/resources/examples/ktor/shortener/shortener.tf
+++ b/plugins/gradle/src/test/resources/examples/ktor/shortener/shortener.tf
@@ -428,6 +428,11 @@ data "aws_iam_policy_document" "merged_0" {
   }
   statement {
     effect = "Allow"
+    resources = ["arn:aws:dynamodb:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:table/ktor-short-url-table/index/*"]
+    actions = ["dynamodb:Query", "dynamodb:Scan"]
+  }
+  statement {
+    effect = "Allow"
     resources = ["arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"]
     actions = ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:DeleteLogGroup", "logs:DeleteLogStream", "logs:DeleteMetricFilter", "logs:DescribeLogGroups", "logs:DescribeLogStreams", "logs:DescribeMetricFilters", "logs:GetLogEvents", "logs:GetLogGroupFields", "logs:GetLogRecord", "logs:GetQueryResults", "logs:PutLogEvents", "logs:PutMetricFilter"]
   }

--- a/plugins/gradle/src/test/resources/examples/spring/shortener/shortener.tf
+++ b/plugins/gradle/src/test/resources/examples/spring/shortener/shortener.tf
@@ -410,6 +410,11 @@ data "aws_iam_policy_document" "io_kotless_examples_page_0" {
   }
   statement {
     effect = "Allow"
+    resources = ["arn:aws:dynamodb:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:table/spring-short-url-table/index/*"]
+    actions = ["dynamodb:Query", "dynamodb:Scan"]
+  }
+  statement {
+    effect = "Allow"
     resources = ["arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"]
     actions = ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:DeleteLogGroup", "logs:DeleteLogStream", "logs:DeleteMetricFilter", "logs:DescribeLogGroups", "logs:DescribeLogStreams", "logs:DescribeMetricFilters", "logs:GetLogEvents", "logs:GetLogGroupFields", "logs:GetLogRecord", "logs:GetQueryResults", "logs:PutLogEvents", "logs:PutMetricFilter"]
   }


### PR DESCRIPTION
It's pretty common to use indexes for DynamoDB tables. However to query/scan an index an application needs permissions for it, not only for the table itself. Check [DynamoDB API Permissions](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/api-permissions-reference.html).
```
To query an index:
    arn:aws:dynamodb:region:account-id:table/table-name/index/index-name
or:
    arn:aws:dynamodb:region:account-id:table/table-name/index/*
```
Right now a Lambda function created with help of kotless will throw "Access Denied" errors if it attempts to use DynamoDB indexes.
This PR grants Query/Scan permissions for all indexes of a table annotated with `@DynamoDBTable`.