### PR TITLE
AWS Lambda log retention config

### DIFF
--- a/engine/src/main/kotlin/io/kotless/terraform/provider/aws/resource/cloudwatch/CloudWatchLogGroup.kt
+++ b/engine/src/main/kotlin/io/kotless/terraform/provider/aws/resource/cloudwatch/CloudWatchLogGroup.kt
@@ -1,0 +1,20 @@
+package io.kotless.terraform.provider.aws.resource.cloudwatch
+
+import io.kotless.terraform.TFFile
+import io.kotless.terraform.TFResource
+
+/**
+ * Terraform aws_cloudwatch_log_group resource.
+ *
+ * @see <a href="https://www.terraform.io/docs/providers/aws/r/aws_cloudwatch_log_group.html">aws_cloudwatch_log_group</a>
+ */
+class CloudWatchLogGroup(id: String) : TFResource(id, "aws_cloudwatch_log_group") {
+    var name by text()
+    var retention_in_days by int()
+}
+
+fun cloudwatch_log_group(id: String, configure: CloudWatchLogGroup.() -> Unit) = CloudWatchLogGroup(id).apply(configure)
+
+fun TFFile.cloudwatch_log_group(id: String, configure: CloudWatchLogGroup.() -> Unit) {
+    add(CloudWatchLogGroup(id).apply(configure))
+}

--- a/plugins/gradle/src/main/kotlin/io/kotless/plugin/gradle/dsl/Converters.kt
+++ b/plugins/gradle/src/main/kotlin/io/kotless/plugin/gradle/dsl/Converters.kt
@@ -17,7 +17,8 @@ internal fun KotlessDSL.toSchema(): KotlessConfig {
                     KotlessConfig.Terraform.AWSProvider(
                         provider.version,
                         provider.profile ?: profile,
-                        provider.region ?: region
+                        provider.region ?: region,
+                        provider.logRetentionInDays
                     )
                 )
             },

--- a/plugins/gradle/src/main/kotlin/io/kotless/plugin/gradle/dsl/KotlessConfig.kt
+++ b/plugins/gradle/src/main/kotlin/io/kotless/plugin/gradle/dsl/KotlessConfig.kt
@@ -156,6 +156,8 @@ class KotlessConfig(project: Project) : Serializable {
             var profile: String? = null
 
             var region: String? = null
+
+            var logRetentionInDays: Int? = null
         }
 
         internal val provider = AWSProvider()

--- a/schema/src/main/kotlin/io/kotless/KotlessConfig.kt
+++ b/schema/src/main/kotlin/io/kotless/KotlessConfig.kt
@@ -51,7 +51,7 @@ data class KotlessConfig(
          * @param profile AWS profile from a local machine to use for Terraform operations authentication
          * @param region AWS region in context of which all Terraform operations should be performed
          */
-        data class AWSProvider(val version: String, val profile: String, val region: String) : Visitable
+        data class AWSProvider(val version: String, val profile: String, val region: String, val logRetentionInDays: Int?) : Visitable
 
         override fun visit(visitor: (Any) -> Unit) {
             aws.visit(visitor)


### PR DESCRIPTION
Resolves https://github.com/JetBrains/kotless/issues/66

Notes:
- Add log retention configuration for AWS lambda log group

Topics to discuss:
- Should all config params supported by tf cloudwatch_log_group be implemented or just log retention config is enough