### PR TITLE
"environment" should be re-assignable and the type of environment should be Map instead of HashMap.

### DIFF
--- a/plugins/gradle/src/main/kotlin/io/kotless/plugin/gradle/dsl/Webapp.kt
+++ b/plugins/gradle/src/main/kotlin/io/kotless/plugin/gradle/dsl/Webapp.kt
@@ -21,7 +21,7 @@ class Webapp(project: Project) : Serializable {
         var timeoutSec: Int = 300
 
         /** Environment that should be additionally passed to lambda */
-        val environment: HashMap<String, String> = HashMap()
+        var environment: Map<String, String> = HashMap()
 
         /** Runtime used to start Lambdas. By default, would be equal to the lowest compatible version.  */
         var runtime: Runtime? = null


### PR DESCRIPTION
kotless > webapp > lambda > environment should be re-assignable and the type of environment should be Map instead of HashMap.