### PR TITLE
#70 Convert binary MIME types for S3 objects

### DIFF
--- a/engine/src/main/kotlin/io/kotless/gen/factory/route/static/StaticRouteFactory.kt
+++ b/engine/src/main/kotlin/io/kotless/gen/factory/route/static/StaticRouteFactory.kt
@@ -67,7 +67,6 @@ object StaticRouteFactory : GenerationFactory<Application.ApiGateway.StaticRoute
             credentials = static_role.role_arn
         }
 
-
         val response = api_gateway_integration_response(context.names.tf(entity.path.parts).ifBlank { "root_resource" }) {
             depends_on = arrayOf(link(method_response.hcl_ref), link(integration.hcl_ref))
 
@@ -77,8 +76,9 @@ object StaticRouteFactory : GenerationFactory<Application.ApiGateway.StaticRoute
             status_code = "200"
             responseParameters(mapOf("method.response.header.Content-Type" to "integration.response.header.Content-Type",
                 "method.response.header.Content-Length" to "integration.response.header.Content-Length"))
+            if(context.schema.statics[entity.resource]!!.mime.isBinary)
+                content_handling = "CONVERT_TO_BINARY"
         }
-
 
         return GenerationFactory.GenerationResult(Output(integration.hcl_ref), method, response, method_response, integration)
     }

--- a/plugins/gradle/src/test/resources/examples/kotless/shortener/shortener.tf
+++ b/plugins/gradle/src/test/resources/examples/kotless/shortener/shortener.tf
@@ -111,6 +111,7 @@ resource "aws_api_gateway_integration_response" "css_shortener_css" {
 
 resource "aws_api_gateway_integration_response" "favicon_apng" {
   depends_on = [aws_api_gateway_integration.favicon_apng, aws_api_gateway_method_response.favicon_apng]
+  content_handling = "CONVERT_TO_BINARY"
   http_method = aws_api_gateway_method.favicon_apng.http_method
   resource_id = aws_api_gateway_resource.favicon_apng.id
   rest_api_id = aws_api_gateway_rest_api.shortener.id

--- a/plugins/gradle/src/test/resources/examples/kotless/site/site.tf
+++ b/plugins/gradle/src/test/resources/examples/kotless/site/site.tf
@@ -224,6 +224,7 @@ resource "aws_api_gateway_integration_response" "css_kotless_site_css" {
 
 resource "aws_api_gateway_integration_response" "favicon_apng" {
   depends_on = [aws_api_gateway_integration.favicon_apng, aws_api_gateway_method_response.favicon_apng]
+  content_handling = "CONVERT_TO_BINARY"
   http_method = aws_api_gateway_method.favicon_apng.http_method
   resource_id = aws_api_gateway_resource.favicon_apng.id
   rest_api_id = aws_api_gateway_rest_api.site.id

--- a/plugins/gradle/src/test/resources/examples/ktor/shortener/shortener.tf
+++ b/plugins/gradle/src/test/resources/examples/ktor/shortener/shortener.tf
@@ -111,6 +111,7 @@ resource "aws_api_gateway_integration_response" "css_shortener_css" {
 
 resource "aws_api_gateway_integration_response" "favicon_apng" {
   depends_on = [aws_api_gateway_integration.favicon_apng, aws_api_gateway_method_response.favicon_apng]
+  content_handling = "CONVERT_TO_BINARY"
   http_method = aws_api_gateway_method.favicon_apng.http_method
   resource_id = aws_api_gateway_resource.favicon_apng.id
   rest_api_id = aws_api_gateway_rest_api.shortener.id

--- a/plugins/gradle/src/test/resources/examples/ktor/site/site.tf
+++ b/plugins/gradle/src/test/resources/examples/ktor/site/site.tf
@@ -224,6 +224,7 @@ resource "aws_api_gateway_integration_response" "css_kotless_site_css" {
 
 resource "aws_api_gateway_integration_response" "favicon_apng" {
   depends_on = [aws_api_gateway_integration.favicon_apng, aws_api_gateway_method_response.favicon_apng]
+  content_handling = "CONVERT_TO_BINARY"
   http_method = aws_api_gateway_method.favicon_apng.http_method
   resource_id = aws_api_gateway_resource.favicon_apng.id
   rest_api_id = aws_api_gateway_rest_api.site.id

--- a/plugins/gradle/src/test/resources/examples/spring/shortener/shortener.tf
+++ b/plugins/gradle/src/test/resources/examples/spring/shortener/shortener.tf
@@ -111,6 +111,7 @@ resource "aws_api_gateway_integration_response" "css_shortener_css" {
 
 resource "aws_api_gateway_integration_response" "favicon_apng" {
   depends_on = [aws_api_gateway_integration.favicon_apng, aws_api_gateway_method_response.favicon_apng]
+  content_handling = "CONVERT_TO_BINARY"
   http_method = aws_api_gateway_method.favicon_apng.http_method
   resource_id = aws_api_gateway_resource.favicon_apng.id
   rest_api_id = aws_api_gateway_rest_api.shortener.id

--- a/plugins/gradle/src/test/resources/examples/spring/site/site.tf
+++ b/plugins/gradle/src/test/resources/examples/spring/site/site.tf
@@ -224,6 +224,7 @@ resource "aws_api_gateway_integration_response" "css_kotless_site_css" {
 
 resource "aws_api_gateway_integration_response" "favicon_apng" {
   depends_on = [aws_api_gateway_integration.favicon_apng, aws_api_gateway_method_response.favicon_apng]
+  content_handling = "CONVERT_TO_BINARY"
   http_method = aws_api_gateway_method.favicon_apng.http_method
   resource_id = aws_api_gateway_resource.favicon_apng.id
   rest_api_id = aws_api_gateway_rest_api.site.id


### PR DESCRIPTION
Fixes #70.

Binary files served from S3 should be converted from base64 to binary format.