### PR TITLE
Fix cron format for Scheduled.everyDay

### DIFF
--- a/dsl/kotless/kotless-lang/src/main/kotlin/io/kotless/dsl/lang/event/Scheduled.kt
+++ b/dsl/kotless/kotless-lang/src/main/kotlin/io/kotless/dsl/lang/event/Scheduled.kt
@@ -24,6 +24,6 @@ annotation class Scheduled(val cron: String, val id: String = "") {
         const val every10Minutes = "0/10 * * * ? *"
         const val everyHour = "0 0/1 * * ? *"
         const val every3Hours = "0 0/3 * * ? *"
-        const val everyDay = "0 0 0/1 * ? *"
+        const val everyDay = "0 0 1/1 * ? *"
     }
 }


### PR DESCRIPTION
- Occurs the following error when using Scheduled.everyDay for a parameter of @Scheduled annotation

```
Exception in thread "main" java.lang.RuntimeException: CronExpression '0 0 0 0/1 * ? *' is invalid.
```

- Because you have specified 0 in the day field
- I changed the value of day field to 1